### PR TITLE
Potential fix for code scanning alert no. 7: Insecure randomness

### DIFF
--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -7,10 +7,8 @@ const origCrypto = globalThis.crypto as any;
 const poly: any = origCrypto ?? webcrypto;
 if (!poly.getRandomValues) {
   poly.getRandomValues = (array: Uint8Array) => {
-    for (let i = 0; i < array.length; i++) {
-      array[i] = Math.floor(Math.random() * 256);
-    }
-    return array;
+    // Use Node's webcrypto to produce secure random bytes
+    return webcrypto.getRandomValues(array);
   };
 }
 if (!poly.randomUUID) {


### PR DESCRIPTION
Potential fix for [https://github.com/healthfees-org/workersql/security/code-scanning/7](https://github.com/healthfees-org/workersql/security/code-scanning/7)

The best way to fix this problem is to update the cryptographic randomness polyfill in `tests/vitest.setup.ts` so that it does not use `Math.random()`, but rather uses the secure random byte generator available in Node. Specifically, where the polyfill defines `getRandomValues`, replace the body that fills `array` with `Math.random()` bytes by a code that delegates to Node's `webcrypto.getRandomValues`. This ensures that both `getRandomValues` and `randomUUID` use secure randomness, matching what would be available on real platforms. No other changes are needed outside of the test polyfill context. The changes should be made at lines 9-14 and wherever `poly.getRandomValues` is defined in `tests/vitest.setup.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
